### PR TITLE
Release of support for HashingAlgorithms.

### DIFF
--- a/lib/src/main/kotlin/dev/robinohs/totpkt/otp/HashAlgorithm.kt
+++ b/lib/src/main/kotlin/dev/robinohs/totpkt/otp/HashAlgorithm.kt
@@ -13,7 +13,7 @@ enum class HashAlgorithm(private val algName: String, val keySize: Int) {
     SHA512("HmacSHA512", 64);
 
     /**
-     * Returns a new [Mac] instance of the [HashAlgorithm].
+     * @return A new [Mac] instance of the [HashAlgorithm].
      */
     fun getMacInstance(): Mac = Mac.getInstance(algName)
 }

--- a/lib/src/main/kotlin/dev/robinohs/totpkt/otp/HashAlgorithm.kt
+++ b/lib/src/main/kotlin/dev/robinohs/totpkt/otp/HashAlgorithm.kt
@@ -1,0 +1,19 @@
+package dev.robinohs.totpkt.otp
+
+import javax.crypto.Mac
+
+/**
+ * @author : Robin Ohs
+ * @created : 06.07.2022
+ * @since : 1.0.0
+ */
+enum class HashAlgorithm(private val algName: String) {
+    SHA1("HmacSHA1"),
+    SHA256("HmacSHA256"),
+    SHA512("HmacSHA512");
+
+    /**
+     * Returns a new [Mac] instance of the [HashAlgorithm].
+     */
+    fun getMacInstance(): Mac = Mac.getInstance(algName)
+}

--- a/lib/src/main/kotlin/dev/robinohs/totpkt/otp/HashAlgorithm.kt
+++ b/lib/src/main/kotlin/dev/robinohs/totpkt/otp/HashAlgorithm.kt
@@ -7,10 +7,10 @@ import javax.crypto.Mac
  * @created : 06.07.2022
  * @since : 1.0.0
  */
-enum class HashAlgorithm(private val algName: String) {
-    SHA1("HmacSHA1"),
-    SHA256("HmacSHA256"),
-    SHA512("HmacSHA512");
+enum class HashAlgorithm(private val algName: String, val keySize: Int) {
+    SHA1("HmacSHA1", 20),
+    SHA256("HmacSHA256", 32),
+    SHA512("HmacSHA512", 64);
 
     /**
      * Returns a new [Mac] instance of the [HashAlgorithm].

--- a/lib/src/main/kotlin/dev/robinohs/totpkt/otp/hotp/HotpGenerator.kt
+++ b/lib/src/main/kotlin/dev/robinohs/totpkt/otp/hotp/HotpGenerator.kt
@@ -1,9 +1,9 @@
 package dev.robinohs.totpkt.otp.hotp
 
+import dev.robinohs.totpkt.otp.HashAlgorithm
 import dev.robinohs.totpkt.otp.OtpGenerator
 import org.apache.commons.codec.binary.Base32
 import java.nio.ByteBuffer
-import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import kotlin.experimental.and
 import kotlin.math.pow
@@ -16,7 +16,10 @@ import kotlin.math.pow
  * @created : 24.06.2022
  * @since : 1.0.0
  */
-open class HotpGenerator(codeLength: Int = 6) : OtpGenerator {
+open class HotpGenerator(
+    open var algorithm: HashAlgorithm = HashAlgorithm.SHA1,
+    codeLength: Int = 6
+) : OtpGenerator {
 
     init {
         require(codeLength >= 0) { "Code length must be >= 0." }
@@ -45,7 +48,7 @@ open class HotpGenerator(codeLength: Int = 6) : OtpGenerator {
 
     private fun generateHash(secret: ByteArray, payload: ByteArray): ByteArray {
         val key = Base32().decode(secret)
-        val mac = Mac.getInstance("HmacSHA1")
+        val mac = algorithm.getMacInstance()
         mac.init(SecretKeySpec(key, "RAW"))
         return mac.doFinal(payload)
     }

--- a/lib/src/main/kotlin/dev/robinohs/totpkt/otp/totp/TotpGenerator.kt
+++ b/lib/src/main/kotlin/dev/robinohs/totpkt/otp/totp/TotpGenerator.kt
@@ -1,5 +1,6 @@
 package dev.robinohs.totpkt.otp.totp
 
+import dev.robinohs.totpkt.otp.HashAlgorithm
 import dev.robinohs.totpkt.otp.hotp.HotpGenerator
 import java.time.Clock
 import java.time.Duration
@@ -10,11 +11,15 @@ import java.time.Duration
  * @since : 1.0.0
  */
 class TotpGenerator(
+    override var algorithm: HashAlgorithm = HashAlgorithm.SHA1,
     codeLength: Int = 6,
     timePeriod: Duration = Duration.ofSeconds(30),
     tolerance: Int = 1,
     var clock: Clock = Clock.systemUTC(),
-) : HotpGenerator(codeLength) {
+) : HotpGenerator(
+    algorithm = algorithm,
+    codeLength = codeLength
+) {
 
     init {
         require(codeLength >= 0) { "Code length must be >= 0." }

--- a/lib/src/main/kotlin/dev/robinohs/totpkt/secret/SecretGenerator.kt
+++ b/lib/src/main/kotlin/dev/robinohs/totpkt/secret/SecretGenerator.kt
@@ -2,6 +2,7 @@ package dev.robinohs.totpkt.secret
 
 import dev.robinohs.totpkt.random.RandomGenerator
 import org.apache.commons.codec.binary.Base32
+import dev.robinohs.totpkt.otp.HashAlgorithm
 
 /**
  * @author : Robin Ohs
@@ -21,4 +22,12 @@ class SecretGenerator(var randomGenerator: RandomGenerator = RandomGenerator()) 
         val secretAsString = Base32().encodeAsString(plainSecret)
         return Base32Secret(secretAsString = secretAsString, secretAsByteArray = secretAsByteArray)
     }
+
+    /**
+     * Generates a secure random secret for a given [HashAlgorithm] and converts it into Base32 encoding.
+     *
+     * @param algorithm the algorithm which preferred key size is taken as length.
+     * @return the secret that can be used in Authenticator apps. E.g., Google Authenticator, Microsoft Authenticator...
+     */
+    fun generateSecret(algorithm: HashAlgorithm): Base32Secret = generateSecret(algorithm.keySize)
 }

--- a/lib/src/test/kotlin/dev/robinohs/totpkt/otp/hotp/HotpGeneratorTest.kt
+++ b/lib/src/test/kotlin/dev/robinohs/totpkt/otp/hotp/HotpGeneratorTest.kt
@@ -3,8 +3,11 @@ package dev.robinohs.totpkt.otp.hotp
 import TestMessageConstants.CODE_SHOULD_BE_VALID_BUT_WAS_NOT
 import TestMessageConstants.CODE_SHOULD_NOT_BE_VALID_BUT_WAS
 import TestMessageConstants.CODE_WAS_NOT_THE_EXPECTED_ONE
+import org.apache.commons.codec.binary.Base32
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.function.Executable
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 /**
  * @author : Robin Ohs
@@ -14,6 +17,7 @@ import org.junit.jupiter.api.function.Executable
 internal class HotpGeneratorTest {
     private val secret = "IJAU CQSB IJAU EQKB".toByteArray()
     private val secret2 = "BJAU CQSB IJAU EQKB".toByteArray()
+    private val secretSpecification = Base32().encode("12345678901234567890".toByteArray())
     private lateinit var cut: HotpGenerator
 
     @BeforeEach
@@ -96,6 +100,27 @@ internal class HotpGeneratorTest {
             Executable { Assertions.assertTrue(actual1) { CODE_SHOULD_BE_VALID_BUT_WAS_NOT } },
             Executable { Assertions.assertFalse(actual2) { CODE_SHOULD_NOT_BE_VALID_BUT_WAS } },
         )
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "0, 755224",
+        "1, 287082",
+        "2, 359152",
+        "3, 969429",
+        "4, 338314",
+        "5, 254676",
+        "6, 287922",
+        "7, 162583",
+        "8, 399871",
+        "9, 520489"
+    )
+    fun testSpecificationDefinedCodes(counter: Long, expected: String) {
+        val actual = cut.generateCode(secretSpecification, counter)
+
+        Assertions.assertEquals(expected, actual) {
+            "Codes should be the same for the given arguments."
+        }
     }
 
 }

--- a/lib/src/test/kotlin/dev/robinohs/totpkt/otp/totp/TotpGeneratorTest.kt
+++ b/lib/src/test/kotlin/dev/robinohs/totpkt/otp/totp/TotpGeneratorTest.kt
@@ -3,7 +3,7 @@ package dev.robinohs.totpkt.otp.totp
 import TestMessageConstants.CODE_SHOULD_BE_VALID_BUT_WAS_NOT
 import TestMessageConstants.CODE_SHOULD_NOT_BE_VALID_BUT_WAS
 import TestMessageConstants.CODE_WAS_NOT_THE_EXPECTED_ONE
-import org.apache.commons.codec.binary.Base32
+import dev.robinohs.totpkt.otp.HashAlgorithm
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
@@ -18,7 +18,6 @@ import java.time.Duration
 internal class TotpGeneratorTest {
     private val secret = "IJAU CQSB IJAU EQKB".toByteArray()
     private val secret2 = "BJAU CQSB IJAU EQKB".toByteArray()
-    private val secretSpecification = Base32().encode("12345678901234567890".toByteArray())
 
     private lateinit var cut: TotpGenerator
 
@@ -314,7 +313,10 @@ internal class TotpGeneratorTest {
     fun testCalculateTimeslotBeginning(timestamp: Long, expected: Long) {
         val actual = cut.calculateTimeslotBeginning(timestamp)
 
-        Assertions.assertEquals(expected, actual) { "Time slot beginning was expected one. $expected not equal to $actual." }
+        Assertions.assertEquals(
+            expected,
+            actual
+        ) { "Time slot beginning was expected one. $expected not equal to $actual." }
     }
 
     @ParameterizedTest
@@ -331,22 +333,72 @@ internal class TotpGeneratorTest {
 
         val actual = cut.calculateRemainingTime(timestamp)
 
-        Assertions.assertEquals(expected, actual) { "Time slot beginning was expected one. $expected not equal to $actual." }
+        Assertions.assertEquals(
+            expected,
+            actual
+        ) { "Time slot beginning was expected one. $expected not equal to $actual." }
     }
 
     @ParameterizedTest
     @CsvSource(
-        "59, 94287082",
-        "1111111109, 07081804",
-        "1111111111, 14050471",
-        "1234567890, 89005924",
-        "2000000000, 69279037",
-        "20000000000, 65353130",
+        "59000, 94287082",
+        "1111111109000, 07081804",
+        "1111111111000, 14050471",
+        "1234567890000, 89005924",
+        "2000000000000, 69279037",
+        "20000000000000, 65353130",
     )
-    fun testSpecificationDefinedCodesSha1(seconds: Long, expected: String) {
+    fun testSpecificationDefinedCodesSha1(millis: Long, expected: String) {
+        cut.algorithm = HashAlgorithm.SHA1
         cut.codeLength = 8
 
-        val actual = cut.generateCode(secretSpecification, seconds * 1000)
+        // 12345678901234567890 encoded to base32
+        val actual = cut.generateCode("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ".toByteArray(), millis)
+
+        Assertions.assertEquals(expected, actual) {
+            "Codes should be the same for the given arguments."
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "59000, 46119246",
+        "1111111109000, 68084774",
+        "1111111111000, 67062674",
+        "1234567890000, 91819424",
+        "2000000000000, 90698825",
+        "20000000000000, 77737706",
+    )
+    fun testSpecificationDefinedCodesSha256(millis: Long, expected: String) {
+        cut.algorithm = HashAlgorithm.SHA256
+        cut.codeLength = 8
+
+        // 12345678901234567890123456789012 encoded to base32
+        val actual = cut.generateCode("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====".toByteArray(), millis)
+
+        Assertions.assertEquals(expected, actual) {
+            "Codes should be the same for the given arguments."
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "59000, 90693936",
+        "1111111109000, 25091201",
+        "1111111111000, 99943326",
+        "1234567890000, 93441116",
+        "2000000000000, 38618901",
+        "20000000000000, 47863826",
+    )
+    fun testSpecificationDefinedCodesSha512(millis: Long, expected: String) {
+        cut.algorithm = HashAlgorithm.SHA512
+        cut.codeLength = 8
+
+        // 1234567890123456789012345678901234567890123456789012345678901234 encoded to base32
+        val actual = cut.generateCode(
+            "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNA=".toByteArray(),
+            millis
+        )
 
         Assertions.assertEquals(expected, actual) {
             "Codes should be the same for the given arguments."

--- a/lib/src/test/kotlin/dev/robinohs/totpkt/otp/totp/TotpGeneratorTest.kt
+++ b/lib/src/test/kotlin/dev/robinohs/totpkt/otp/totp/TotpGeneratorTest.kt
@@ -3,6 +3,7 @@ package dev.robinohs.totpkt.otp.totp
 import TestMessageConstants.CODE_SHOULD_BE_VALID_BUT_WAS_NOT
 import TestMessageConstants.CODE_SHOULD_NOT_BE_VALID_BUT_WAS
 import TestMessageConstants.CODE_WAS_NOT_THE_EXPECTED_ONE
+import org.apache.commons.codec.binary.Base32
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.params.ParameterizedTest
@@ -17,6 +18,7 @@ import java.time.Duration
 internal class TotpGeneratorTest {
     private val secret = "IJAU CQSB IJAU EQKB".toByteArray()
     private val secret2 = "BJAU CQSB IJAU EQKB".toByteArray()
+    private val secretSpecification = Base32().encode("12345678901234567890".toByteArray())
 
     private lateinit var cut: TotpGenerator
 
@@ -330,5 +332,24 @@ internal class TotpGeneratorTest {
         val actual = cut.calculateRemainingTime(timestamp)
 
         Assertions.assertEquals(expected, actual) { "Time slot beginning was expected one. $expected not equal to $actual." }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "59, 94287082",
+        "1111111109, 07081804",
+        "1111111111, 14050471",
+        "1234567890, 89005924",
+        "2000000000, 69279037",
+        "20000000000, 65353130",
+    )
+    fun testSpecificationDefinedCodesSha1(seconds: Long, expected: String) {
+        cut.codeLength = 8
+
+        val actual = cut.generateCode(secretSpecification, seconds * 1000)
+
+        Assertions.assertEquals(expected, actual) {
+            "Codes should be the same for the given arguments."
+        }
     }
 }

--- a/lib/src/test/kotlin/dev/robinohs/totpkt/secret/SecretGeneratorTest.kt
+++ b/lib/src/test/kotlin/dev/robinohs/totpkt/secret/SecretGeneratorTest.kt
@@ -1,5 +1,6 @@
 package dev.robinohs.totpkt.secret
 
+import dev.robinohs.totpkt.otp.HashAlgorithm
 import dev.robinohs.totpkt.random.RandomGenerator
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -88,6 +89,72 @@ internal class SecretGeneratorTest {
     )
     fun testGenerateSecret_byteArrayAndStringAreEqual(length: Int) {
         val base32Secret = cut.generateSecret(length)
+        val secretAsByteArray = base32Secret.secretAsByteArray.toString(Charsets.UTF_8)
+        val secretAsString = base32Secret.secretAsString
+
+        assertEquals(secretAsByteArray, secretAsString) {
+            "The generated secret as bytearray and as string are equal."
+        }
+    }
+
+    @Test
+    fun testGenerateSecret_sha1Algorithm() {
+        val expected = "IJAUCQSBIJAUEQKBIJBECQKCIJAUCQSC"
+
+        val (actual, _) = cut.generateSecret(HashAlgorithm.SHA1)
+
+        assertEquals(expected, actual) {
+            "The generated secret as bytearray and as string are equal."
+        }
+    }
+
+    @Test
+    fun testGenerateSecret_sha1AlgorithmEqual() {
+        val base32Secret = cut.generateSecret(HashAlgorithm.SHA1)
+        val secretAsByteArray = base32Secret.secretAsByteArray.toString(Charsets.UTF_8)
+        val secretAsString = base32Secret.secretAsString
+
+        assertEquals(secretAsByteArray, secretAsString) {
+            "The generated secret as bytearray and as string are equal."
+        }
+    }
+
+    @Test
+    fun testGenerateSecret_sha256Algorithm() {
+        val expected = "IJAUCQSBIJAUEQKBIJBECQKCIJAUCQSCIJAUCQKCIFAUCQKCIJBA===="
+
+        val (actual, _) = cut.generateSecret(HashAlgorithm.SHA256)
+
+        assertEquals(expected, actual) {
+            "The generated secret as bytearray and as string are equal."
+        }
+    }
+
+    @Test
+    fun testGenerateSecret_sha256AlgorithmEqual() {
+        val base32Secret = cut.generateSecret(HashAlgorithm.SHA256)
+        val secretAsByteArray = base32Secret.secretAsByteArray.toString(Charsets.UTF_8)
+        val secretAsString = base32Secret.secretAsString
+
+        assertEquals(secretAsByteArray, secretAsString) {
+            "The generated secret as bytearray and as string are equal."
+        }
+    }
+
+    @Test
+    fun testGenerateSecret_sha512Algorithm() {
+        val expected = "IJAUCQSBIJAUEQKBIJBECQKCIJAUCQSCIJAUCQKCIFAUCQKCIJBEEQKBIJAUCQSBIJAUCQSBIFBEEQKBIFBECQKBIFAUEQSCIFBECQI="
+
+        val (actual, _) = cut.generateSecret(HashAlgorithm.SHA512)
+
+        assertEquals(expected, actual) {
+            "The generated secret as bytearray and as string are equal."
+        }
+    }
+
+    @Test
+    fun testGenerateSecret_sha512AlgorithmEqual() {
+        val base32Secret = cut.generateSecret(HashAlgorithm.SHA512)
         val secretAsByteArray = base32Secret.secretAsByteArray.toString(Charsets.UTF_8)
         val secretAsString = base32Secret.secretAsString
 


### PR DESCRIPTION
Merge dev into main:
- add support to specify used hashing algorithm for HMAC creation (SHA1, SHA256, SHA512)
- add method to secret generator to generate keys with preferred length for the different algorithms.